### PR TITLE
Add windows x64 and arm64 aot publish

### DIFF
--- a/.github/workflows/release_stable_cli.yaml
+++ b/.github/workflows/release_stable_cli.yaml
@@ -20,10 +20,8 @@ jobs:
                       "linux-arm",
                       "linux-arm64",
                       "osx-x64",
-                      "win-x64",
                       "win-x86",
-                      "win-arm",
-                      "win-arm64",
+                      "win-arm"
                   ]
       steps:
         - name: Checkout
@@ -52,9 +50,47 @@ jobs:
               name: rdb-cli
               path: /home/runner/work/release
 
+    publish_windows_x64_and_arm_aot:
+      name: Build and upload windows x64 and arm64 aot cli artifact
+      runs-on: windows-latest
+      strategy:
+          matrix:
+              targets:
+                  [
+                    "win-x64",
+                    "win-arm64"
+                  ]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v1
+        - name: Setup .NET Core SDK 6.x
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: 6.x
+        - name: Publish .NET app
+          env:
+              RID: ${{ matrix.targets }}
+              VERSION: ${{ github.ref_name }}
+          run: dotnet publish src/RDBCli/RDBCli.csproj -c Release -r $($env:RID) -p:UseAot=true -p:DebugType=None -p:DebugSymbols=false --self-contained true --output ../publish/$($env:RID)
+
+        - name: Package assets
+          env:
+              RID: ${{ matrix.targets }}
+              VERSION: ${{ github.ref_name }}
+          run: |
+              mkdir ../release
+              rm -fo ../publish/$($env:RID)/*.pdb
+              ls ../publish/
+              Compress-Archive -Path ../publish/$($env:RID)/* -DestinationPath ../release/rdb-cli.$($env:VERSION).$($env:RID).zip
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          with:
+              name: rdb-cli
+              path: D:/a/rdb-tools/release
+
     release_cli:
         name: Publish release
-        needs: publish_cli
+        needs: ['publish_cli','publish_windows_x64_and_arm_aot']
         runs-on: ubuntu-latest
     
         steps:          

--- a/.github/workflows/release_unstable_cli.yaml
+++ b/.github/workflows/release_unstable_cli.yaml
@@ -19,10 +19,8 @@ jobs:
                       "linux-arm",
                       "linux-arm64",
                       "osx-x64",
-                      "win-x64",
                       "win-x86",
-                      "win-arm",
-                      "win-arm64",
+                      "win-arm"
                   ]
       steps:
         - name: Checkout
@@ -51,9 +49,47 @@ jobs:
               name: rdb-cli
               path: /home/runner/work/release
 
+    publish_windows_x64_and_arm_aot:
+      name: Build and upload windows x64 and arm64 aot cli artifact
+      runs-on: windows-latest
+      strategy:
+          matrix:
+              targets:
+                  [
+                    "win-x64",
+                    "win-arm64"
+                  ]
+      steps:
+        - name: Checkout
+          uses: actions/checkout@v1
+        - name: Setup .NET Core SDK 6.x
+          uses: actions/setup-dotnet@v2
+          with:
+            dotnet-version: 6.x
+        - name: Publish .NET app
+          env:
+              RID: ${{ matrix.targets }}
+              VERSION: ${{ github.ref_name }}
+          run: dotnet publish src/RDBCli/RDBCli.csproj -c Release -r $($env:RID) -p:UseAot=true -p:DebugType=None -p:DebugSymbols=false --self-contained true --output ../publish/$($env:RID)
+
+        - name: Package assets
+          env:
+              RID: ${{ matrix.targets }}
+              VERSION: ${{ github.ref_name }}
+          run: |
+              mkdir ../release
+              rm -fo ../publish/$($env:RID)/*.pdb
+              ls ../publish/
+              Compress-Archive -Path ../publish/$($env:RID)/* -DestinationPath ../release/rdb-cli.$($env:VERSION).$($env:RID).zip
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v2
+          with:
+              name: rdb-cli
+              path: D:/a/rdb-tools/release
+
     release_cli:
         name: Publish release
-        needs: publish_cli
+        needs: ['publish_cli','publish_windows_x64_and_arm_aot']
         runs-on: ubuntu-latest
     
         steps:          

--- a/src/RDBCli/RDBCli.csproj
+++ b/src/RDBCli/RDBCli.csproj
@@ -18,10 +18,15 @@
 		<ToolCommandName>$(AssemblyName)</ToolCommandName>
 		<PackAsTool>true</PackAsTool>
 		<InvariantGlobalization>true</InvariantGlobalization>
+		<UseAot>false</UseAot>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
+	</ItemGroup>
+
+	<ItemGroup Condition="$(UseAot)">
+		<PackageReference Include="Microsoft.DotNet.ILCompiler;runtime.win-x64.Microsoft.DotNet.ILCompiler" Version="7.0.0-*"/>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Add windows platform AOT publish. use AOT publish can reduced program start-up time and size.
Below is a comparison of the program's data and the time taken to process the 190mb size rdb file.
**Before**
|Size|Compressed Size|Time|
|----|----|----|
|10.1MB|5.3MB|720ms|

**After**
|Size|Compressed Size|Time|
|----|----|----|
|6.85MB|2.7MB|1097ms|
